### PR TITLE
Add AWS CLI formatting shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ A curated list of awesome Bash aliases.
 
 Website: https://vikaskyadav.github.io/awesome-bash-alias/
 
+__# AWS CLI__
+* alias awstb='f(){ aws "$@" --output table; unset -f f; }; f'
+* alias awstx='f(){ aws "$@" --output text; unset -f f; }; f'
+* alias awsjs='f(){ aws "$@" --output json; unset -f f; }; f'
+
 __# Calculator__
 * alias bc="bc -l"
 


### PR DESCRIPTION
Ideally, these functions would exist in ~/.profile or bash_profile, but since the specific request is for aliases, I've embedded temporary functions in the alias itself.  

awsjs - format aws cli output in JSON
awstb - format aws cli output in tables
awstx - format aws cli output in plaintext